### PR TITLE
refactors the `calculateCIs` function 

### DIFF
--- a/R/estimateCIs.R
+++ b/R/estimateCIs.R
@@ -98,16 +98,15 @@ calculateCIs <- function(tbl,
   # Compute design_effect based on what is available
   if (!is.null(m_vals) && !is.null(rho_vals)) {
     design_effect <- sqrt(1 + (as.numeric(m_vals) - 1) * as.numeric(rho_vals))
-  } else if (
-    isTRUE(doubleentered) &&
-    is.null(m_vals) &&
-    is.null(rho_vals)
-  ) {
-    design_effect <- rep(sqrt(1 + (2 - 1) * 1), n_rows)
   } else {
     design_effect <- rep(adjust_base, n_rows)
   }
-
+  if (
+    isTRUE(doubleentered)
+  ) {
+    # Adjust standard errors for double entry
+    design_effect <- design_effect * sqrt(2)
+  }
   z_crit <- stats::qnorm((1 + conf_level) / 2)
 
   if (method == "raykov") {


### PR DESCRIPTION
This pull request refactors the `calculateCIs` function in the `R/estimateCIs.R` file to simplify the logic and improve the handling of double entry adjustments. The most important changes include removing redundant conditions and introducing a new adjustment for standard errors when double entry is enabled.

### Refactoring and logic simplification:
* Removed redundant condition that calculated `design_effect` specifically for cases where `doubleentered` is `TRUE` and `m_vals` and `rho_vals` are both `NULL`. This simplifies the code by eliminating unnecessary branches.

### Handling double entry adjustments:
* Added a new adjustment to `design_effect` for double entry cases by multiplying it by `sqrt(2)`, ensuring proper scaling of standard errors.